### PR TITLE
docs: fix project name in CONTRIBUTING.md heading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Antigravity
+# Contributing to PREVENT Dawn
 
 Welcome! This guide outlines our development workflow and standards to help us build a secure, personalized diabetes prevention platform.
 


### PR DESCRIPTION
## Summary

- The CONTRIBUTING.md heading read '# Contributing to Antigravity', a leftover from a previous project name
- Changed it to '# Contributing to PREVENT Dawn' to match the actual project

## Test plan

- Verify CONTRIBUTING.md heading reads '# Contributing to PREVENT Dawn'

Generated with Claude Code